### PR TITLE
fix(css): migrate from deprecated css.Sass to resources.ToCSS

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -1,5 +1,5 @@
 {{ $scss := resources.Get "scss/main.scss" }}
-{{ $css := $scss | css.Sass | resources.Minify | resources.Fingerprint }}
+{{ $css := $scss | resources.ToCSS | resources.Minify | resources.Fingerprint }}
 <link rel="stylesheet" href="{{ $css.RelPermalink }}" integrity="{{ $css.Data.Integrity }}">
 
 {{ $js := resources.Get "js/main.js" }}


### PR DESCRIPTION
Problem
The theme currently uses `css.Sass` function which has been deprecated in Hugo v0.111.0+.  This causes build failures when using modern Hugo versions: ERROR: can't evaluate field Sass in type interface {}

Solution
Replace `css.Sass` with `resources.ToCSS` - the official replacement API introduced in Hugo v0.111.0+.

Compatibility Impact
✅ Hugo v0.111.0+: Fully supported
❌ Hugo v0.100.0 - v0.110.0: No longer supported

Why drop support for older versions?
Hugo v0.111.0 was released over 2 years ago (June 2023)

Most users have upgraded to newer versions

Maintaining dual API compatibility would significantly increase code complexity

Users on older Hugo versions are encouraged to upgrade for security and features

Testing
Hugo Version: v0.123.7 (extended)